### PR TITLE
Update GeometryFactory.cs

### DIFF
--- a/Terradue.GeoJson/Terradue/GeoJson/Geometry/GeometryFactory.cs
+++ b/Terradue.GeoJson/Terradue/GeoJson/Geometry/GeometryFactory.cs
@@ -114,9 +114,8 @@ namespace Terradue.GeoJson.Geometry {
         /// </summary>
         /// <param name="wkt">The geometry in WKT to convert</param>
         public static GeometryObject WktToGeometry(string wkt) {
-            wkt.Trim();
-            wkt = wkt.Replace(", ", ",");
-            Match match = Regex.Match(wkt, @"^([A-Z]+)\((.+)\)$");
+            wkt = wkt.Trim().Replace(", ", ",");
+            Match match = Regex.Match(wkt, @"^([A-Z]+)\s*\((.+)\)$");
             if (match.Success) {
                 switch (match.Groups[1].Value) {
                     case "MULTIPOLYGON":


### PR DESCRIPTION
The trim command result was not used.

The regular expression does not take into account WKT with a space between the identifier and the coordinates failing this case "MULTIPOLYGON (((...)))" only passes if the WKT has no space like this "MULTIPOLYGON(((...)))"
